### PR TITLE
Set Up CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,82 @@ jobs:
       - name: Build
         run: cargo build --verbose --workspace
 
-      - name: Tests
+      - name: Run Tests
         run: cargo test --verbose --workspace
 
-      - name: Ignored (Slow) Tests
+      - name: Run Ignored (Slow) Tests
         run: cargo test --verbose --workspace -- --ignored
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-docs
+
+      - name: Build docs
+        env:
+          RUSTDOCFLAGS: "-Dwarnings"
+        run: cargo doc --verbose --workspace --document-private-items
+
+  docs-rs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust Nightly Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-docs-rs
+        uses: dtolnay/install@cargo-docs-rs
+
+      - name: Build docs as docs.rs does
+        run: cargo docs-rs --verbose
+
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Typos
+        uses: crate-ci/typos@v1
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install cargo-msrv
+        uses: taiki-e/install-action@v2
+        with:
+          tools: cargo-msrv@0.16.0-beta.20
+
+      - name: Verify MSRV
+        run: cargo msrv verify
+
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust Nightly Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-minimal-versions
+        uses: taiki-e/install-action@v2
+        with:
+          tools: cargo-hack,cargo-minimal-versions    
+
+      - name: Check Minimal Versions of Dependencies
+        run: cargo minimal-versions check --workspace
+
+      - name: Test Minimal Versions of Dependencies
+        run: cargo minimal-versions test --workspace

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Typos
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@v1.18.2
 
   msrv:
     runs-on: ubuntu-latest
@@ -105,7 +105,7 @@ jobs:
       - name: Install cargo-msrv
         uses: taiki-e/install-action@v2
         with:
-          tools: cargo-msrv@0.16.0-beta.20
+          tool: cargo-msrv@0.16.0-beta.20
 
       - name: Verify MSRV
         run: cargo msrv verify
@@ -122,7 +122,7 @@ jobs:
       - name: Install cargo-minimal-versions
         uses: taiki-e/install-action@v2
         with:
-          tools: cargo-hack,cargo-minimal-versions    
+          tool: cargo-hack,cargo-minimal-versions    
 
       - name: Check Minimal Versions of Dependencies
         run: cargo minimal-versions check --workspace

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Rust Format Check
+        run: cargo fmt --verbose --check --all
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Clippy Checks
+        run: cargo clippy --verbose --workspace --tests -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --verbose --workspace
+
+      - name: Tests
+        run: cargo test --verbose --workspace
+
+      - name: Ignored (Slow) Tests
+        run: cargo test --verbose --workspace -- --ignored

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,10 +102,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install cargo-msrv
+      - name: Install cargo-binstall
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-msrv@0.16.0-beta.20
+          tool: cargo-binstall
+
+      - name: Install cargo-msrv
+        run: cargo binstall --version 0.16.0-beta.20 --no-confirm cargo-msrv
 
       - name: Verify MSRV
         run: cargo msrv verify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ pedantic = "warn"
 [workspace.dependencies]
 compose_spec_macros = { version = "=0.1.0", path = "compose_spec_macros" }
 serde = "1"
-serde_yaml = "0.9.30"
+serde_yaml = "0.9"
 
 [package]
 name = "compose_spec"
@@ -38,10 +38,10 @@ workspace = true
 compose_spec_macros.workspace = true
 indexmap = { version = "2", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
-serde-untagged = "0.1.5"
+serde-untagged = "0.1"
 serde_yaml.workspace = true
-thiserror = "1.0.56"
-url = { version = "2.5", features = ["serde"] }
+thiserror = "1.0.7"
+url = { version = "2.3", features = ["serde"] }
 
 [dev-dependencies]
-proptest = "1.4"
+proptest = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 license = "MPL-2.0"
 readme = "README.md"
 repository = "https://github.com/k9withabone/compose_spec_rs"
+rust-version = "1.70"
 
 [workspace.lints.clippy]
 pedantic = "warn"
@@ -25,6 +26,7 @@ edition.workspace = true
 license.workspace = true
 readme.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 description = "Types for (de)serializing from/to the compose-spec"
 keywords = ["compose", "containers", "docker", "podman"]
 categories = ["api-bindings"]

--- a/compose_spec_macros/Cargo.toml
+++ b/compose_spec_macros/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 readme.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 description = "Procedural macros for use in the compose_spec crate"
 
 [lib]

--- a/compose_spec_macros/Cargo.toml
+++ b/compose_spec_macros/Cargo.toml
@@ -16,9 +16,9 @@ proc-macro = true
 workspace = true
 
 [dependencies]
-proc-macro2 = "1.0.78"
-quote = "1.0.35"
-syn = "2.0.48"
+proc-macro2 = "1"
+quote = "1"
+syn = "2"
 
 [dev-dependencies]
 serde.workspace = true


### PR DESCRIPTION
Set up the GitHub actions CI for the repository. To start, jobs have been set up for checking formatting, clippy, tests, documentation, spelling, MSRV, and ensuring minimal dependency versions work.