### PR TITLE
Add undeprecated fields to `Service`

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -433,6 +433,22 @@ pub struct Service {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<MacAddress>,
 
+    /// The amount of memory the container can allocate.
+    ///
+    /// Must be consistent with `memory` in [`deploy::resources::Limits`] if both are set.
+    ///
+    /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#mem_limit)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mem_limit: Option<ByteValue>,
+
+    /// The amount of memory the container reserves for use.
+    ///
+    /// Must be consistent with `memory` in [`deploy::resources::Reservations`] if both are set.
+    ///
+    /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#mem_reservation)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mem_reservation: Option<ByteValue>,
+
     /// Percentage of anonymous pages the host kernel is allowed to swap.
     ///
     /// The default is platform specific.

--- a/src/service.rs
+++ b/src/service.rs
@@ -483,6 +483,14 @@ pub struct Service {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pid: Option<String>,
 
+    /// Tune the container's PIDs limit.
+    ///
+    /// Must be consistent with `pids` in [`deploy::resources::Limits`] if both are set.
+    ///
+    /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#pids_limit)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pids_limit: Option<u32>,
+
     /// Target platform for the container to run on.
     ///
     /// Used to determine which version of the container image is pulled and/or which platform the

--- a/src/service.rs
+++ b/src/service.rs
@@ -55,7 +55,7 @@ pub use self::{
     config_or_secret::ConfigOrSecret,
     cpuset::{CpuSet, ParseCpuSetError},
     credential_spec::{CredentialSpec, Kind as CredentialSpecKind},
-    deploy::Deploy,
+    deploy::{resources::Cpus, Deploy},
     develop::Develop,
     device::Device,
     env_file::EnvFile,
@@ -166,6 +166,14 @@ pub struct Service {
         with = "duration_option"
     )]
     pub cpu_rt_period: Option<Duration>,
+
+    /// Number of (potentially virtual) CPUs to allocate to the container.
+    ///
+    /// Must be consistent with `cpus` in [`Deploy`] if both are set.
+    ///
+    /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#cpus)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpus: Option<Cpus>,
 
     /// CPUs in which to allow execution.
     ///

--- a/src/service/deploy/resources.rs
+++ b/src/service/deploy/resources.rs
@@ -109,7 +109,7 @@ pub struct Reservations {
 /// Must be a positive and finite number.
 ///
 /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/deploy.md#cpus)
-#[derive(Serialize, Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Serialize, Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
 #[serde(into = "f64")]
 pub struct Cpus(f64);
 

--- a/src/service/volumes/mount.rs
+++ b/src/service/volumes/mount.rs
@@ -7,6 +7,7 @@ use std::{
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
     ops::Not,
+    path::PathBuf,
 };
 
 use serde::{Deserialize, Serialize};
@@ -305,6 +306,10 @@ pub struct VolumeOptions {
     #[serde(default, skip_serializing_if = "Not::not")]
     pub nocopy: bool,
 
+    /// Path inside the volume to mount instead of the volume root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subpath: Option<PathBuf>,
+
     /// Extension values, which are (de)serialized via flattening.
     ///
     /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/11-extension.md)
@@ -314,17 +319,28 @@ pub struct VolumeOptions {
 
 impl PartialEq for VolumeOptions {
     fn eq(&self, other: &Self) -> bool {
-        let Self { nocopy, extensions } = self;
+        let Self {
+            nocopy,
+            subpath,
+            extensions,
+        } = self;
 
-        *nocopy == other.nocopy && extensions.as_slice() == other.extensions.as_slice()
+        *nocopy == other.nocopy
+            && *subpath == other.subpath
+            && extensions.as_slice() == other.extensions.as_slice()
     }
 }
 
 impl Hash for VolumeOptions {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let Self { nocopy, extensions } = self;
+        let Self {
+            nocopy,
+            subpath,
+            extensions,
+        } = self;
 
         nocopy.hash(state);
+        subpath.hash(state);
         extensions.as_slice().hash(state);
     }
 }


### PR DESCRIPTION
Adds recently undeprecated fields to `Service` and the new `subpath` field to `service::volumes::mount::VolumeOptions`.