### PR TITLE
ci: add semver-checks job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,3 +132,12 @@ jobs:
 
       - name: Test Minimal Versions of Dependencies
         run: cargo minimal-versions test --workspace
+
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ If you are submitting code changes in a pull request and would like to run the C
   - Install [cargo-minimal-versions](https://github.com/taiki-e/cargo-minimal-versions).
   - `cargo minimal-versions check --workspace`
   - `cargo minimal-versions test --workspace`
+- semver-checks:
+  - Install [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks-action).
+  - `cargo semver-checks`
 
 ## License
 


### PR DESCRIPTION
Uses cargo-semver-checks to make sure the package version is increased correctly when making changes.