### PR TITLE
Basic Validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compose_spec"
-version = "0.2.0"
+version = "0.2.1-alpha.1"
 dependencies = [
  "compose_spec_macros",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ sort_commits = "oldest"
 
 [package]
 name = "compose_spec"
-version = "0.2.0"
+version = "0.2.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/common/short_or_long.rs
+++ b/src/common/short_or_long.rs
@@ -102,6 +102,17 @@ where
     }
 }
 
+impl<K, V> ShortOrLong<IndexSet<K>, IndexMap<K, V>> {
+    /// Returns an [`Iterator`] of items in the list of the [`Short`](Self::Short) syntax or the
+    /// keys in the map of the [`Long`](Self::Long) syntax.
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &K> {
+        match self {
+            Self::Short(set) => ShortOrLong::Short(set.iter()),
+            Self::Long(map) => ShortOrLong::Long(map.keys()),
+        }
+    }
+}
+
 /// Trait for types that represent a long syntax which could also be represented in a short syntax.
 pub trait AsShort {
     /// The short syntax type, returned from [`as_short()`](AsShort::as_short()).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,26 @@ pub struct Compose {
 }
 
 impl Compose {
+    /// Ensure that all [`Resource`]s ([`Network`]s, [`Volume`]s, [`Config`]s, and [`Secret`]s) used
+    /// in each [`Service`] are defined in the appropriate top-level field.
+    ///
+    /// Runs, in order, [`validate_networks()`](Self::validate_networks()),
+    /// [`validate_volumes()`](Self::validate_volumes()),
+    /// [`validate_configs()`](Self::validate_configs()), and
+    /// [`validate_secrets()`](Self::validate_secrets()).
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error encountered, meaning an [`Identifier`] for a [`Resource`] was used
+    /// in a [`Service`] which is not defined in the appropriate top-level field.
+    pub fn validate_all(&self) -> Result<(), ValidationError> {
+        self.validate_networks()?;
+        self.validate_volumes()?;
+        self.validate_configs()?;
+        self.validate_secrets()?;
+        Ok(())
+    }
+
     /// Ensure that the networks used in each [`Service`] are defined in the `networks` field.
     ///
     /// # Errors

--- a/src/service.rs
+++ b/src/service.rs
@@ -42,8 +42,8 @@ use crate::{
         default_true, display_from_str_option, duration_option, duration_us_option, skip_true,
         ItemOrListVisitor,
     },
-    AsShortIter, Extensions, Identifier, InvalidIdentifierError, ItemOrList, ListOrMap, Map,
-    MapKey, Networks, ShortOrLong, StringOrNumber, Value,
+    AsShortIter, Configs, Extensions, Identifier, InvalidIdentifierError, ItemOrList, ListOrMap,
+    Map, MapKey, Networks, ShortOrLong, StringOrNumber, Value,
 };
 
 use self::build::Context;
@@ -701,6 +701,24 @@ impl Service {
                 if !networks.contains_key(network) {
                     return Err(network.clone());
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Ensure that all configs used by the service are defined in the top-level `configs` field of
+    /// the [`Compose`](crate::Compose) file.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first config [`Identifier`] which is not in the given [`Configs`] as an error.
+    pub(crate) fn validate_configs(&self, configs: &Configs) -> Result<(), Identifier> {
+        for config in &self.configs {
+            let (ShortOrLong::Short(source) | ShortOrLong::Long(ConfigOrSecret { source, .. })) =
+                config;
+            if !configs.contains_key(source) {
+                return Err(source.clone());
             }
         }
 

--- a/src/service/build/context.rs
+++ b/src/service/build/context.rs
@@ -25,7 +25,6 @@ pub enum Context {
     /// This path must be a directory and must contain a `Dockerfile`/`Containerfile`.
     Path(PathBuf),
 
-    #[allow(rustdoc::bare_urls)]
     /// A URL context.
     ///
     /// Git URLs accept context configuration in their fragment section, separated by a colon (:).
@@ -38,6 +37,7 @@ pub enum Context {
     /// Other types of contexts can be defined in the `additional_contexts` field of the
     /// long [`Build`](super::Build) syntax by using alternative schemes such as `docker-image://`
     /// or `oci-layout://`.
+    #[allow(rustdoc::bare_urls, clippy::doc_markdown)]
     Url(Url),
 }
 

--- a/src/service/volumes.rs
+++ b/src/service/volumes.rs
@@ -47,6 +47,22 @@ pub fn into_long_iter(volumes: Volumes) -> impl Iterator<Item = Mount> {
     volumes.into_iter().map(Into::into)
 }
 
+/// Return an [`Iterator`] of [`Identifier`]s for named volumes used as sources in the [`Volumes`].
+pub(crate) fn named_volumes_iter(volumes: &Volumes) -> impl Iterator<Item = &Identifier> {
+    volumes.iter().filter_map(|volume| match volume {
+        ShortOrLong::Short(ShortVolume {
+            options:
+                Some(ShortOptions {
+                    source: Source::Volume(volume),
+                    ..
+                }),
+            ..
+        }) => Some(volume),
+        ShortOrLong::Long(Mount::Volume(Volume { source, .. })) => source.as_ref(),
+        _ => None,
+    })
+}
+
 /// Short [`Service`](super::Service) container volume syntax.
 ///
 /// (De)serializes from/to a string in the format `[{source}:]{container_path}[:{options}]`, where


### PR DESCRIPTION
Adds methods to `Compose` for ensuring that all networks, volumes, configs, and secrets used by each `Service` are defined in the corresponding top-level field.

Closes: #18