### PR TITLE
Fragments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compose_spec"
-version = "0.2.1-alpha.1"
+version = "0.2.1-alpha.2"
 dependencies = [
  "compose_spec_macros",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ sort_commits = "oldest"
 
 [package]
 name = "compose_spec"
-version = "0.2.1-alpha.1"
+version = "0.2.1-alpha.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub mod duration;
 mod include;
 mod name;
 pub mod network;
+mod options;
 pub mod secret;
 mod serde;
 pub mod service;
@@ -97,6 +98,7 @@ pub use self::{
     include::Include,
     name::{InvalidNameError, Name},
     network::Network,
+    options::Options,
     secret::Secret,
     service::Service,
     volume::Volume,
@@ -192,6 +194,29 @@ pub struct Compose {
 }
 
 impl Compose {
+    /// Builder for options to apply when deserializing a Compose file.
+    ///
+    /// Alias for [`Options::default()`].
+    ///
+    /// ```
+    /// use compose_spec::Compose;
+    ///
+    /// let yaml = "\
+    /// services:
+    ///   hello:
+    ///     image: quay.io/podman/hello:latest
+    /// ";
+    ///
+    /// let compose = Compose::options()
+    ///     // ... add deserialization options
+    ///     .from_yaml_str(yaml)?;
+    /// # Ok::<(), serde_yaml::Error>(())
+    /// ```
+    #[must_use]
+    pub fn options() -> Options {
+        Options::default()
+    }
+
     /// Ensure that all [`Resource`]s ([`Network`]s, [`Volume`]s, [`Config`]s, and [`Secret`]s) used
     /// in each [`Service`] are defined in the appropriate top-level field.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,36 @@
 //! syntax types which may be represented directly as the [`Short`] syntax type if additional
 //! options are not set.
 //!
+//! # [Fragments](https://github.com/compose-spec/compose-spec/blob/master/10-fragments.md)
+//!
+//! [`serde_yaml`] does use YAML anchors and aliases during deserialization. However, it does not
+//! automatically merge the [YAML merge type](https://yaml.org/type/merge.html) (`<<` keys). You
+//! can use [`serde_yaml::Value::apply_merge()`] to merge `<<` keys into the surrounding mapping.
+//! [`Options::apply_merge()`] is available to do this for you.
+//!
+//! ```
+//! use compose_spec::Compose;
+//!
+//! let yaml = "\
+//! services:
+//!   one:
+//!     environment: &env
+//!       FOO: foo
+//!       BAR: bar
+//!   two:
+//!     environment: *env
+//!   three:
+//!     environment:
+//!       <<: *env
+//!       BAR: baz
+//! ";
+//!
+//! let compose = Compose::options()
+//!     .apply_merge(true)
+//!     .from_yaml_str(yaml)?;
+//! # Ok::<(), serde_yaml::Error>(())
+//! ```
+//!
 //! [Compose specification]: https://github.com/compose-spec/compose-spec
 //! [`Short`]: ShortOrLong::Short
 //! [`Long`]: ShortOrLong::Long

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,0 +1,51 @@
+//! [`Options`] builder for deserialization options for a [`Compose`] file.
+
+use std::io::Read;
+
+use crate::{Compose, YamlValue};
+
+/// Deserialization options builder for a [`Compose`] file.
+#[allow(missing_copy_implementations)] // Will include interpolation vars as a HashMap.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Options {
+    /// TODO
+    merge_anchors: bool,
+}
+
+impl Options {
+    /// Use the set options to deserialize a [`Compose`] file from a string slice of YAML.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deserialization fails.
+    pub fn from_yaml_str(&self, yaml: &str) -> serde_yaml::Result<Compose> {
+        serde_yaml::from_str(yaml)
+    }
+
+    /// Use the set options to deserialize a [`Compose`] file from an IO stream of YAML.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deserialization fails.
+    pub fn from_yaml_reader<R: Read>(&self, reader: R) -> serde_yaml::Result<Compose> {
+        serde_yaml::from_reader(reader)
+    }
+
+    /// Use the set options to deserialize a [`Compose`] file from bytes of YAML.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deserialization fails.
+    pub fn from_yaml_slice(&self, slice: &[u8]) -> serde_yaml::Result<Compose> {
+        serde_yaml::from_slice(slice)
+    }
+
+    /// Use the set options to deserialize a [`Compose`] file from a YAML [`Value`](YamlValue).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if deserialization fails.
+    pub fn from_yaml_value(&self, value: YamlValue) -> serde_yaml::Result<Compose> {
+        serde_yaml::from_value(value)
+    }
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -8,18 +8,64 @@ use crate::{Compose, YamlValue};
 #[allow(missing_copy_implementations)] // Will include interpolation vars as a HashMap.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Options {
-    /// TODO
-    merge_anchors: bool,
+    /// Whether to perform merging of `<<` keys.
+    apply_merge: bool,
 }
 
 impl Options {
+    /// Set whether to merge `<<` keys into the surrounding mapping.
+    ///
+    /// ```
+    /// use compose_spec::Compose;
+    ///
+    /// let yaml = "
+    /// services:
+    ///   one:
+    ///     environment: &env
+    ///       FOO: foo
+    ///       BAR: bar
+    ///   two:
+    ///     environment:
+    ///       <<: *env
+    ///       BAR: baz
+    /// ";
+    ///
+    /// let compose = Compose::options()
+    ///     .apply_merge(true)
+    ///     .from_yaml_str(yaml)
+    ///     .unwrap();
+    ///
+    /// let two_env = compose.services["two"]
+    ///     .environment
+    ///     .clone()
+    ///     .into_map()
+    ///     .unwrap();
+    ///
+    /// assert_eq!(two_env["FOO"].as_ref().unwrap().as_string().unwrap(), "foo");
+    /// assert_eq!(two_env["BAR"].as_ref().unwrap().as_string().unwrap(), "baz");
+    /// ```
+    pub fn apply_merge(&mut self, apply_merge: bool) -> &mut Self {
+        self.apply_merge = apply_merge;
+        self
+    }
+
+    /// Return `true` if any options are set.
+    const fn any(&self) -> bool {
+        let Self { apply_merge } = *self;
+        apply_merge
+    }
+
     /// Use the set options to deserialize a [`Compose`] file from a string slice of YAML.
     ///
     /// # Errors
     ///
     /// Returns an error if deserialization fails.
     pub fn from_yaml_str(&self, yaml: &str) -> serde_yaml::Result<Compose> {
-        serde_yaml::from_str(yaml)
+        if self.any() {
+            self.from_yaml_value(serde_yaml::from_str(yaml)?)
+        } else {
+            serde_yaml::from_str(yaml)
+        }
     }
 
     /// Use the set options to deserialize a [`Compose`] file from an IO stream of YAML.
@@ -28,7 +74,11 @@ impl Options {
     ///
     /// Returns an error if deserialization fails.
     pub fn from_yaml_reader<R: Read>(&self, reader: R) -> serde_yaml::Result<Compose> {
-        serde_yaml::from_reader(reader)
+        if self.any() {
+            self.from_yaml_value(serde_yaml::from_reader(reader)?)
+        } else {
+            serde_yaml::from_reader(reader)
+        }
     }
 
     /// Use the set options to deserialize a [`Compose`] file from bytes of YAML.
@@ -37,7 +87,11 @@ impl Options {
     ///
     /// Returns an error if deserialization fails.
     pub fn from_yaml_slice(&self, slice: &[u8]) -> serde_yaml::Result<Compose> {
-        serde_yaml::from_slice(slice)
+        if self.any() {
+            self.from_yaml_value(serde_yaml::from_slice(slice)?)
+        } else {
+            serde_yaml::from_slice(slice)
+        }
     }
 
     /// Use the set options to deserialize a [`Compose`] file from a YAML [`Value`](YamlValue).
@@ -45,7 +99,10 @@ impl Options {
     /// # Errors
     ///
     /// Returns an error if deserialization fails.
-    pub fn from_yaml_value(&self, value: YamlValue) -> serde_yaml::Result<Compose> {
+    pub fn from_yaml_value(&self, mut value: YamlValue) -> serde_yaml::Result<Compose> {
+        if self.apply_merge {
+            value.apply_merge()?;
+        }
         serde_yaml::from_value(value)
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -18,7 +18,7 @@ impl Options {
     /// ```
     /// use compose_spec::Compose;
     ///
-    /// let yaml = "
+    /// let yaml = "\
     /// services:
     ///   one:
     ///     environment: &env


### PR DESCRIPTION
Adds deserialization options via `Compose::options()`. Merge the YAML merge type (`<<` keys) with `Options::apply_merge()`.

Closes #2