### PR TITLE
fix(service): image registry with port is valid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compose_spec"
-version = "0.2.1-alpha.2"
+version = "0.2.1-alpha.3"
 dependencies = [
  "compose_spec_macros",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ sort_commits = "oldest"
 
 [package]
 name = "compose_spec"
-version = "0.2.1-alpha.2"
+version = "0.2.1-alpha.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Image names with a registry that have a port are now valid.

Changed `compose_spec::service::image::Name::new()` to allow for using `compose_spec::service::Image::set_registry()` with a registry with a port. The first part of a name is now treated as a registry if it has a dot (.) regardless of whether the name has multiple parts.

Added `compose_spec::service::image::InvalidNamePart::RegistryPort` error variant for when a registry's port is not a valid port number.

Refactored image tests to not use `unwrap()`.

Fixes #22