### PR TITLE
fix(service): support host IP in brackets for `ports` short syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compose_spec"
-version = "0.2.1-alpha.3"
+version = "0.2.1-alpha.4"
 dependencies = [
  "compose_spec_macros",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ sort_commits = "oldest"
 
 [package]
 name = "compose_spec"
-version = "0.2.1-alpha.3"
+version = "0.2.1-alpha.4"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/service.rs
+++ b/src/service.rs
@@ -1078,16 +1078,23 @@ where
                 de::Error::custom("extra host value must be a string representing an IP address")
             })?;
 
-            // Remove brackets possibly surrounding IP address, e.g. `[::1]`
-            let value = value.strip_prefix('[').unwrap_or(value);
-            let value = value.strip_suffix(']').unwrap_or(value);
-
             Ok((
                 Hostname::new(key).map_err(de::Error::custom)?,
-                value.parse().map_err(de::Error::custom)?,
+                strip_brackets(value).parse().map_err(de::Error::custom)?,
             ))
         })
         .collect()
+}
+
+/// Remove surrounding square brackets from a string slice.
+///
+/// If the brackets are not in a pair, then the string is returned unchanged.
+///
+/// For example, an IPv6 address may be in brackets, `[::1]` to `::1`.
+fn strip_brackets(s: &str) -> &str {
+    s.strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(s)
 }
 
 /// IPC isolation mode for a [`Service`] container.


### PR DESCRIPTION
Extracted bracket striping logic from `extra_hosts` deserialization into its own function: `compose_spec::service::strip_brackets()`.

Used `strip_brackets()` for host IP parsing in `impl FromStr for compose_spec::service::ports::ShortPort`.

Added test `compose_spec::service::ports::tests::short_port::host_ip_brackets()` to ensure the fix is working as expected.

Fixes: #24