### PR TITLE
fix(service)!: `user` may have an optional group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compose_spec"
-version = "0.2.1-alpha.4"
+version = "0.3.0-alpha.1"
 dependencies = [
  "compose_spec_macros",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ sort_commits = "oldest"
 
 [package]
 name = "compose_spec"
-version = "0.2.1-alpha.4"
+version = "0.3.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/service.rs
+++ b/src/service.rs
@@ -19,7 +19,7 @@ pub mod network_config;
 pub mod platform;
 pub mod ports;
 mod ulimit;
-pub mod user_or_group;
+pub mod user;
 pub mod volumes;
 
 use std::{
@@ -38,10 +38,7 @@ use thiserror::Error;
 
 use crate::{
     impl_from_str,
-    serde::{
-        default_true, display_from_str_option, duration_option, duration_us_option, skip_true,
-        ItemOrListVisitor,
-    },
+    serde::{default_true, duration_option, duration_us_option, skip_true, ItemOrListVisitor},
     AsShortIter, Configs, Extensions, Identifier, InvalidIdentifierError, ItemOrList, ListOrMap,
     Map, MapKey, Networks, Secrets, ShortOrLong, StringOrNumber, Value,
 };
@@ -67,7 +64,7 @@ pub use self::{
     platform::Platform,
     ports::Ports,
     ulimit::{InvalidResourceError, Resource, Ulimit, Ulimits},
-    user_or_group::UserOrGroup,
+    user::{IdOrName, User},
     volumes::{AbsolutePath, Volumes},
 };
 
@@ -351,7 +348,7 @@ pub struct Service {
     ///
     /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#group_add)
     #[serde(default, skip_serializing_if = "IndexSet::is_empty")]
-    pub group_add: IndexSet<UserOrGroup>,
+    pub group_add: IndexSet<IdOrName>,
 
     /// A check that is run to determine whether the service container is "healthy".
     ///
@@ -648,12 +645,8 @@ pub struct Service {
     /// The default is set by the image or is `root`.
     ///
     /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#user)
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "display_from_str_option::serialize"
-    )]
-    pub user: Option<UserOrGroup>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
 
     /// User namespace mode for the container.
     ///

--- a/src/test-full.yaml
+++ b/src/test-full.yaml
@@ -564,7 +564,7 @@ services:
         soft: 100
         hard: 200
         x-test: test
-    user: user
+    user: user:group
     userns_mode: userns_mode
     volumes:
       - /container


### PR DESCRIPTION
Before this fix values for `services[].user` that included a GID or group name were rejected. The Compose Specification is unfortunately vague for `user` (see https://github.com/compose-spec/compose-spec/issues/39). However, both `docker run --user` and `podman run --user` accept the `{user}[:{group}]` syntax.

Renamed `compose_spec::service::UserOrGroup` to `IdOrName`.

Renamed `compose_spec::service::user_or_group` module to `user`.

Added `compose_spec::service::User`.

Changed the type of the `user` field in `compose_spec::Service` to `Option<User>`.

Fixes: #23