### PR TITLE
feat(service)!: add `services[].networks[].driver_opts` attribute

### DIFF
--- a/src/test-full.yaml
+++ b/src/test-full.yaml
@@ -392,6 +392,9 @@ services:
           - 127.0.0.1
           - ::1
         mac_address: 92:d0:c6:0a:29:33
+        driver_opts:
+          foo: "bar"
+          baz: 1
         priority: 100
         x-test: test
 


### PR DESCRIPTION
Added the `driver_opts` field to
`compose_spec::service::network_config::Network`.

`compose_spec::service::network_config::{NetworkConfig, Network}` no longer implement `Eq` due to `compose_spec::StringOrNumber` use in `driver_opts`.

Closes: #29