### PR TITLE
fix(service)!: support unlimited ulimits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compose_spec"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 dependencies = [
  "compose_spec_macros",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ sort_commits = "oldest"
 
 [package]
 name = "compose_spec"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/src/common/short_or_long.rs
+++ b/src/common/short_or_long.rs
@@ -27,7 +27,7 @@ use crate::{
         env_file,
         ports::{Port, ShortPort},
         volumes::{Mount, ShortVolume},
-        Build, ConfigOrSecret, Ulimit,
+        Build, ConfigOrSecret, Limit, Ulimit,
     },
     Identifier, Include,
 };
@@ -246,6 +246,18 @@ impl_from_short! {
 impl<L> From<String> for ShortOrLong<PathBuf, L> {
     fn from(value: String) -> Self {
         Self::Short(value.into())
+    }
+}
+
+impl<T, L> From<Limit<T>> for ShortOrLong<Limit<T>, L> {
+    fn from(value: Limit<T>) -> Self {
+        Self::Short(value)
+    }
+}
+
+impl<L> From<u64> for ShortOrLong<Limit<u64>, L> {
+    fn from(value: u64) -> Self {
+        Limit::Value(value).into()
     }
 }
 

--- a/src/service/limit.rs
+++ b/src/service/limit.rs
@@ -32,6 +32,12 @@ impl From<u32> for Limit<u32> {
     }
 }
 
+impl From<u64> for Limit<u64> {
+    fn from(value: u64) -> Self {
+        Self::Value(value)
+    }
+}
+
 impl From<ByteValue> for Limit<ByteValue> {
     fn from(value: ByteValue) -> Self {
         Self::Value(value)

--- a/src/service/ulimit.rs
+++ b/src/service/ulimit.rs
@@ -8,13 +8,15 @@ use thiserror::Error;
 
 use crate::{common::key_impls, AsShort, Extensions, ShortOrLong};
 
+use super::Limit;
+
 /// Override the default ulimits for a [`Service`](super::Service) container.
 ///
-/// Ulimits are defined as map from a [`Resource`] to either a singe limit ([`u64`]) or a mapping
-/// of a soft and hard limit ([`Ulimit`]).
+/// Ulimits are defined as map from a [`Resource`] to either a singe limit ([`Limit<u64>`]) or a
+/// mapping of a soft and hard limit ([`Ulimit`]).
 ///
 /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#ulimits)
-pub type Ulimits = IndexMap<Resource, ShortOrLong<u64, Ulimit>>;
+pub type Ulimits = IndexMap<Resource, ShortOrLong<Limit<u64>, Ulimit>>;
 
 /// [`Ulimit`] resource name (e.g. "nofile").
 ///
@@ -77,10 +79,10 @@ key_impls!(Resource => InvalidResourceError);
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Ulimit {
     /// Soft limit.
-    pub soft: u64,
+    pub soft: Limit<u64>,
 
     /// Hard limit.
-    pub hard: u64,
+    pub hard: Limit<u64>,
 
     /// Extension values, which are (de)serialized via flattening.
     ///
@@ -90,7 +92,7 @@ pub struct Ulimit {
 }
 
 impl AsShort for Ulimit {
-    type Short = u64;
+    type Short = Limit<u64>;
 
     fn as_short(&self) -> Option<&Self::Short> {
         let Self {
@@ -105,6 +107,12 @@ impl AsShort for Ulimit {
 
 impl From<u64> for Ulimit {
     fn from(value: u64) -> Self {
+        Limit::Value(value).into()
+    }
+}
+
+impl From<Limit<u64>> for Ulimit {
+    fn from(value: Limit<u64>) -> Self {
         Self {
             soft: value,
             hard: value,

--- a/src/test-full.yaml
+++ b/src/test-full.yaml
@@ -84,6 +84,10 @@ services:
           soft: 100
           hard: 200
           x-test: test
+        unlimited: -1
+        unlimitedlong:
+            soft: -1
+            hard: -1
       platforms:
         - linux/amd64
         - linux/arm
@@ -567,6 +571,10 @@ services:
         soft: 100
         hard: 200
         x-test: test
+      unlimited: -1
+      unlimitedlong:
+          soft: -1
+          hard: -1
     user: user:group
     userns_mode: userns_mode
     volumes:


### PR DESCRIPTION
Changed `soft` and `hard` fields of `compose_spec::service::Ulimit` to `compose_spec::service::Limit<u64>`.

Changed `compose_spec::service::Ulimits` type alias (used for `ulimits` field of `compose_spec::Service` and `compose_spec::service::Build`) to `IndexMap<Resource, ShortOrLong<Limit<u64>, Ulimit>>`.

Changed `<Ulimit as AsShort>::Short` to `Limit<u64>`.

Added `impl From<Limit<u64>> for Ulimit`.

Added `impl From<u64> for Limit<u64>`.

Added `impl<T, L> From<Limit<T>> for ShortOrLong<Limit<T>, L>` and `impl<L> From<u64> for ShortOrLong<Limit<u64>, L>`.

Fixes: #31