### PR TITLE
feat(service): add `Limit` string conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compose_spec"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 dependencies = [
  "compose_spec_macros",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ sort_commits = "oldest"
 
 [package]
 name = "compose_spec"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Added `Display` and `FromStr` implementations to `compose_spec::service::Limit`.

Changed the string deserialization logic of `Limit` to deserialize the string "-1" as `Limit::Unlimited`.