### PR TITLE
feat(service)!: support `network_mode: container:{name}`

### DIFF
--- a/src/test-full.yaml
+++ b/src/test-full.yaml
@@ -378,6 +378,9 @@ services:
   network_mode-service:
     network_mode: service:service
 
+  network_mode-container:
+    network_mode: container:container
+
   network_mode-other:
     network_mode: other
 


### PR DESCRIPTION
Added the `compose_spec::service::network_config::NetworkMode::Container` enum variant.