### PR TITLE
chore(lints): Rust v1.82 Clippy lint fixes

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -41,6 +41,7 @@ pub use self::{
 /// [anchors and aliases](https://github.com/compose-spec/compose-spec/blob/master/10-fragments.md).
 ///
 /// [compose-spec](https://github.com/compose-spec/compose-spec/blob/master/11-extension.md)
+#[allow(clippy::too_long_first_doc_paragraph)] // false positive, see https://github.com/rust-lang/rust-clippy/issues/13315
 pub type Extensions = IndexMap<ExtensionKey, YamlValue>;
 
 /// A single item or a list of unique items.

--- a/src/service/ports.rs
+++ b/src/service/ports.rs
@@ -157,6 +157,7 @@ impl Port {
     /// # Errors
     ///
     /// Returns ownership if this long syntax cannot be represented as the short syntax.
+    #[allow(clippy::result_large_err)]
     pub fn into_short(self) -> Result<ShortPort, Self> {
         if self.name.is_none()
             && self.app_protocol.is_none()

--- a/src/service/volumes/mount.rs
+++ b/src/service/volumes/mount.rs
@@ -186,6 +186,7 @@ impl Mount {
     /// # Errors
     ///
     /// Returns ownership if this long syntax cannot be represented as the short syntax.
+    #[allow(clippy::result_large_err)]
     pub fn into_short(self) -> Result<ShortVolume, Self> {
         match self {
             Self::Volume(volume) => volume.into_short().map_err(Self::Volume),
@@ -269,6 +270,7 @@ impl Volume {
     /// # Errors
     ///
     /// Returns ownership if this long syntax cannot be represented as the short syntax.
+    #[allow(clippy::result_large_err)]
     pub fn into_short(self) -> Result<ShortVolume, Self> {
         match self {
             Self {
@@ -399,6 +401,7 @@ impl Bind {
     /// # Errors
     ///
     /// Returns ownership if this long syntax cannot be represented as the short syntax.
+    #[allow(clippy::result_large_err)]
     pub fn into_short(self) -> Result<ShortVolume, Self> {
         match self {
             Self {


### PR DESCRIPTION
Allowed `clippy::too_long_first_doc_paragraph` on `compose_spec::Extensions` due to false positive, see rust-lang/rust-clippy#13315.

Allowed `clippy::result_large_err` on `into_short()` methods as they are returning ownership on error and are not expected to be bubbled up directly.