### PR TITLE
test: adding os-matrix for unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,12 @@ jobs:
         run: cargo clippy --verbose --workspace --tests -- -D warnings
 
   test:
-    runs-on: ubuntu-latest
+    name: unit tests / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

When trying to investigate https://github.com/k9withabone/compose_spec_rs/issues/38 I find out that the problem was only occurring on Windows.

The problem is occurring in the code below, the `is_absolute` is platform specific.

https://github.com/k9withabone/compose_spec_rs/blob/1c6924bf396acc7ec7c8d7a134f55d9a8e7eb211/src/service/volumes.rs#L310-L314

Quoting the rust documentation

> Returns true if the Path is absolute, i.e., if it is independent of the current directory.
> - On Unix, a path is absolute if it starts with the root, so is_absolute and [has_root](https://doc.rust-lang.org/std/path/struct.Path.html#method.has_root) are equivalent.
> - On Windows, a path is absolute if it has a prefix and starts with the root: c:\windows is absolute, while c:temp and \temp are not.

Source https://doc.rust-lang.org/std/path/struct.Path.html

The `ContainerPath` is always POSIX, so the is_absolute cannot be used on it, since on windows it would fails

## Context

This PR does not fix the problem, as I am not familiar with the code, and with the numerous usage of the `AbsolutePath` struct I don't want to risk to break everything!

This PR is adding an os-matrix for testing. (Today it fails, but if https://github.com/k9withabone/compose_spec_rs/issues/38 is fixed, a simple rebase should be enough)