### PR TITLE
Moving to the `containers` Organization

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Typos
-        uses: crate-ci/typos@v1.26.0
+        uses: crate-ci/typos@v1
 
   msrv:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Ensures that all secrets used in each service is defined in the top-level `secrets` field of the `Compose` file.
 - Add `Compose::validate_all()`.
 - Add `Compose::options()` for setting deserialization options.
-- Add `Options::apply_merge()`. ([#2](https://github.com/k9withabone/compose_spec_rs/issues/2))
+- Add `Options::apply_merge()`. ([#2](https://github.com/containers/compose_spec_rs/issues/2))
   - Merges `<<` keys into the surrounding mapping.
-- **BREAKING** *(service)* Add `services[].networks[].driver_opts` attribute. ([#29](https://github.com/k9withabone/compose_spec_rs/issues/29))
+- **BREAKING** *(service)* Add `services[].networks[].driver_opts` attribute. ([#29](https://github.com/containers/compose_spec_rs/issues/29))
   - Added the `driver_opts` field to `compose_spec::service::network_config::Network`.
 - *(service)* Add `Limit` string conversions.
   - Added `Display` and `FromStr` implementations to `compose_spec::service::Limit`.
@@ -29,19 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added the `compose_spec::service::network_config::NetworkMode::Container` enum variant.
 
 ### Bug Fixes
-- *(service)* Image registry with port is valid. ([#22](https://github.com/k9withabone/compose_spec_rs/issues/22))
+- *(service)* Image registry with port is valid. ([#22](https://github.com/containers/compose_spec_rs/issues/22))
   - Image names with a registry that have a port are now valid.
   - Changed `compose_spec::service::image::Name::new()` to allow for using `compose_spec::service::Image::set_registry()` with a registry with a port. The first part of a name is now treated as a registry if it has a dot (.) regardless of whether the name has multiple parts.
   - Added `compose_spec::service::image::InvalidNamePart::RegistryPort` error variant for when a registry's port is not a valid port number.
   - Refactored image tests to not use `unwrap()`.
-- *(service)* Support host IP in brackets for `ports` short syntax. ([#24](https://github.com/k9withabone/compose_spec_rs/issues/24))
-- **BREAKING** *(service)* `user` may have an optional group. ([#23](https://github.com/k9withabone/compose_spec_rs/issues/23))
+- *(service)* Support host IP in brackets for `ports` short syntax. ([#24](https://github.com/containers/compose_spec_rs/issues/24))
+- **BREAKING** *(service)* `user` may have an optional group. ([#23](https://github.com/containers/compose_spec_rs/issues/23))
   - Before this fix values for `services[].user` that included a GID or group name were rejected. The Compose Specification is unfortunately vague for `user` (see https://github.com/compose-spec/compose-spec/issues/39). However, both `docker run --user` and `podman run --user` accept the `{user}[:{group}]` syntax.
   - Renamed `compose_spec::service::UserOrGroup` to `IdOrName`.
   - Renamed `compose_spec::service::user_or_group` module to `user`.
   - Added `compose_spec::service::User`.
   - Changed the type of the `user` field in `compose_spec::Service` to `Option<User>`.
-- **BREAKING** *(service)* Support unlimited ulimits. ([#31](https://github.com/k9withabone/compose_spec_rs/issues/31))
+- **BREAKING** *(service)* Support unlimited ulimits. ([#31](https://github.com/containers/compose_spec_rs/issues/31))
   - Changed `soft` and `hard` fields of `compose_spec::service::Ulimit` to `compose_spec::service::Limit<u64>`.
   - Changed `compose_spec::service::Ulimits` type alias (used for `ulimits` field of `compose_spec::Service` and `compose_spec::service::Build`) to `IndexMap<Resource, ShortOrLong<Limit<u64>, Ulimit>>`.
   - Changed `<Ulimit as AsShort>::Short` to `Limit<u64>`.
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 - Add fragment documentation.
-- *(macros)* Add symlink to `LICENSE` file. ([#21](https://github.com/k9withabone/compose_spec_rs/issues/21))
+- *(macros)* Add symlink to `LICENSE` file. ([#21](https://github.com/containers/compose_spec_rs/issues/21))
   - This ensures that the `LICENSE` file is included when the `compose_spec_macros` package is published to crates.io via `cargo publish`.
 - *(changelog)* Update git-cliff config for v2.6.0.
 
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `compose_spec::{Identifier, MapKey, ExtensionKey, service::{build::CacheOption, user_or_group::Name, Hostname, Resource}}`
 - *(service)* Add `service::volumes::mount::Tmpfs::from_target()`.
   - Also implemented `From<service::volumes::AbsolutePath>` for `service::volumes::mount::Tmpfs` using the new function.
-- **BREAKING** *(service)* Add `entitlements` field to `service::Build` ([#15](https://github.com/k9withabone/compose_spec_rs/issues/15)).
+- **BREAKING** *(service)* Add `entitlements` field to `service::Build` ([#15](https://github.com/containers/compose_spec_rs/issues/15)).
 
 ### Bug Fixes
 - **BREAKING** *(service)* Allow for unlimited `pids_limit`.
@@ -134,6 +134,6 @@ The initial release of `compose_spec`!
 - Conversion between short and long syntax forms of values.
 - Conversion between `std::time::Duration` and the duration string format from the compose-spec.
 
-[0.3.0]: https://github.com/k9withabone/compose_spec_rs/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/k9withabone/compose_spec_rs/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/k9withabone/compose_spec_rs/compare/51a31d82c34c13cf8881bf8a9cbda74a6b6aa9b6...v0.1.0
+[0.3.0]: https://github.com/containers/compose_spec_rs/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/containers/compose_spec_rs/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/containers/compose_spec_rs/compare/51a31d82c34c13cf8881bf8a9cbda74a6b6aa9b6...v0.1.0

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,3 @@
+## The Community Code of Conduct
+
+The `compose_spec_rs` repository follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,154 @@
+# Contributing to the `compose_spec_rs` Repository
+
+We'd love to have you join the community! Below summarizes the processes that we follow.
+
+## Reporting Issues
+
+Before reporting an issue, check our backlog of
+[open issues](https://github.com/containers/compose_spec_rs/issues)
+to see if someone else has already reported it. If so, feel free to add
+your scenario, or additional information, to the discussion. Or simply
+"subscribe" to it to be notified when it is updated.
+
+If you find a new issue with the project we'd love to hear about it! The most
+important aspect of a bug report is that it includes enough information for
+us to reproduce it. So, please include as much detail as possible and try
+to remove the extra stuff that doesn't really relate to the issue itself.
+The easier it is for us to reproduce it, the faster it'll be fixed!
+
+Please don't include any private/sensitive information in your issue!
+
+## Submitting Pull Requests
+
+No [pull request] (PR) is too small! Typos, additional comments in the code,
+new test cases, bug fixes, new features, more documentation, ... it's all
+welcome!
+
+While bug fixes can first be identified via an [issue], that is not required.
+It's ok to just open up a PR with the fix, but make sure you include the same
+information you would have included in an issue - like how to reproduce it.
+
+PRs for new features should include some background on what use cases the
+new code is trying to address. When possible and when it makes sense, try to break up
+larger PRs into smaller ones - it's easier to review smaller
+code changes. But only if those smaller ones make sense as stand-alone PRs.
+
+Commits that fix issues should include one or more footers like `Closes: #XXX` or `Fixes: #XXX` at
+the end of the commit message. GitHub will automatically close the referenced issue when the PR is
+merged and the [changelog] will include the issue.
+
+### Use Conventional Commits
+
+Try to use [conventional commits](https://www.conventionalcommits.org) for your commit messages.
+It makes reviewing the commit log and creating the [changelog] via
+[git-cliff](https://git-cliff.org/) easier.
+
+### Sign Your Commits
+
+For a PR to be merged, each commit must contain a `Signed-off-by` footer. The sign-off is a
+line at the end of the explanation for the commit. Your signature certifies that you wrote the patch
+or otherwise have the right to pass it on as an open-source patch.
+
+The rules are simple: if you can certify the following (from
+[developercertificate.org](https://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+```
+Signed-off-by: Joe Smith <joe.smith@email.com>
+```
+
+Use your real name (sorry, no pseudonyms or anonymous contributions).
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.
+
+### Project Layout
+
+`compose_spec` is composed of two packages set up in a Cargo workspace. The root package,
+`compose_spec`, is the main library. The other package, `compose_spec_macros`, located in a
+directory of the same name, is a procedural macro library used in `compose_spec`.
+`compose_spec_macros` is not designed to be used outside the `compose_spec` library.
+
+### Local Continuous Integration (CI)
+
+A number of jobs are automatically run for each pull request and merge.
+If you are submitting code changes in a pull request and would like to run the CI jobs locally,
+use the following commands:
+
+- format: `cargo fmt --check --all`
+- clippy: `cargo clippy --workspace --tests`
+- test: `cargo test --workspace -- --include-ignored`
+- doc: `cargo doc --workspace --document-private-items`
+- docs-rs:
+  - Install the nightly Rust toolchain, `rustup toolchain install nightly`.
+  - Install [cargo-docs-rs](https://github.com/dtolnay/cargo-docs-rs).
+  - `cargo docs-rs`
+- spellcheck:
+  - Install [typos](https://github.com/crate-ci/typos).
+  - `typos`
+- msrv:
+  - Install [cargo-msrv](https://github.com/foresterre/cargo-msrv).
+  - `cargo msrv verify`
+- minimal-versions:
+  - Install the nightly Rust toolchain, `rustup toolchain install nightly`.
+  - Install [cargo-hack](https://github.com/taiki-e/cargo-hack).
+  - Install [cargo-minimal-versions](https://github.com/taiki-e/cargo-minimal-versions).
+  - `cargo minimal-versions check --workspace`
+  - `cargo minimal-versions test --workspace`
+- semver-checks:
+  - Install [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks-action).
+  - `cargo semver-checks`
+
+## Communication
+
+This project shares communication channels with other projects in the
+[Containers organization](https://github.com/containers#-community), specifically Podlet, which has
+its own dedicated channels on the Podman Discord, `#podlet` and `#podlet-dev`.
+
+For discussions about issues, bugs, or features, feel free to create an [issue], [discussion], or
+[pull request] on GitHub.
+
+
+[changelog]: ./CHANGELOG.md
+[discussion]: https://github.com/containers/compose_spec_rs/discussions
+[issue]: https://github.com/containers/compose_spec_rs/issues
+[pull request]: https://github.com/containers/compose_spec_rs/pulls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "compose_spec"
-version = "0.3.1-alpha.1"
+version = "0.3.1-alpha.2"
 dependencies = [
  "compose_spec_macros",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Paul Nettleton <k9@k9withabone.dev>"]
 edition = "2024"
 license = "MPL-2.0"
 readme = "README.md"
-repository = "https://github.com/k9withabone/compose_spec_rs"
+repository = "https://github.com/containers/compose_spec_rs"
 rust-version = "1.85"
 
 [workspace.lints.rust]
@@ -101,7 +101,7 @@ features_always_bump_minor = false
 breaking_always_bump_major = false
 
 [workspace.metadata.git-cliff.remote.github]
-owner = "k9withabone"
+owner = "containers"
 repo = "compose_spec_rs"
 
 [workspace.metadata.git-cliff.changelog]
@@ -226,7 +226,7 @@ sort_commits = "oldest"
 
 [package]
 name = "compose_spec"
-version = "0.3.1-alpha.1"
+version = "0.3.1-alpha.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,10 @@
+#  Maintainers
+
+The `compose_spec_rs` repository is a community project maintained by volunteers. They may be contacted directly in case of a security vulnerability.
+However, if possible, please use GitHub's private security vulnerability reporting feature by pressing the "Report a vulnerability" button on the repository's [security](https://github.com/containers/compose_spec_rs/security) page.
+For all other communication, please use one of the [communication channels](./CONTRIBUTING.md#Communication).
+
+| Maintainer     | Project Role         | GitHub                                          | Matrix                              | Discord                  | Email                                                                         |
+| -------------- | -------------------- | ----------------------------------------------- | ----------------------------------- | ------------------------ | ----------------------------------------------------------------------------- |
+| Paul Nettleton | Maintainer (Creator) | [k9withabone](https://github.com/k9withabone)   | @k9withabone:matrix.org (Preferred) | k9withabone              | [k9@k9withabone.dev](mailto:k9@k9withabone.dev)                               |
+| Martin Beckert | Maintainer           | [TheRealBecks](https://github.com/TheRealBecks) |                                     | therealbecks (Preferred) | [martin.beckert@strukturpiloten.de](mailto:martin.beckert@strukturpiloten.de) |

--- a/README.md
+++ b/README.md
@@ -65,41 +65,9 @@ Increasing the MSRV is **not** considered to be a breaking change.
 
 ## Contribution
 
-Contributions, suggestions, and/or comments are appreciated! Feel free to create an [issue](https://github.com/containers/compose_spec_rs/issues), [discussion](https://github.com/containers/compose_spec_rs/discussions), or [pull request](https://github.com/containers/compose_spec_rs/pulls).
-Generally, it is preferable to start a discussion for a feature request or open an issue for reporting a bug before submitting changes with a pull request.
-
-### Project Layout
-
-`compose_spec` is composed of two packages set up in a Cargo workspace. The root package, `compose_spec`, is the main library.
-The other package, `compose_spec_macros`, located in a directory of the same name, is a procedural macro library used in `compose_spec`. `compose_spec_macros` is not designed to be used outside the `compose_spec` library.
-
-### Local CI
-
-If you are submitting code changes in a pull request and would like to run the CI jobs locally, use the following commands:
-
-- format: `cargo fmt --check --all`
-- clippy: `cargo clippy --workspace --tests`
-- test: `cargo test --workspace -- --include-ignored`
-- doc: `cargo doc --workspace --document-private-items`
-- docs-rs:
-  - Install the nightly Rust toolchain, `rustup toolchain install nightly`.
-  - Install [cargo-docs-rs](https://github.com/dtolnay/cargo-docs-rs).
-  - `cargo docs-rs`
-- spellcheck:
-  - Install [typos](https://github.com/crate-ci/typos).
-  - `typos`
-- msrv:
-  - Install [cargo-msrv](https://github.com/foresterre/cargo-msrv).
-  - `cargo msrv verify`
-- minimal-versions:
-  - Install the nightly Rust toolchain, `rustup toolchain install nightly`.
-  - Install [cargo-hack](https://github.com/taiki-e/cargo-hack).
-  - Install [cargo-minimal-versions](https://github.com/taiki-e/cargo-minimal-versions).
-  - `cargo minimal-versions check --workspace`
-  - `cargo minimal-versions test --workspace`
-- semver-checks:
-  - Install [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks-action).
-  - `cargo semver-checks`
+Contributions, suggestions, and/or comments are appreciated! See the
+[contribution guide](./CONTRIBUTING.md) for more information on reporting issues, submitting pull
+requests, the project layout, running CI tasks locally, and communication channels.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io MSRV](https://img.shields.io/crates/msrv/compose_spec?style=flat-square&logo=rust)](#minimum-supported-rust-version-msrv)
 [![docs.rs](https://img.shields.io/docsrs/compose_spec?style=flat-square&logo=rust)](https://docs.rs/compose_spec)
 [![License](https://img.shields.io/crates/l/compose_spec?style=flat-square)](./LICENSE)
-[![GitHub Actions CI Workflow Status](https://img.shields.io/github/actions/workflow/status/k9withabone/compose_spec_rs/ci.yaml?branch=main&style=flat-square&logo=github&label=ci)](https://github.com/k9withabone/compose_spec_rs/actions/workflows/ci.yaml?query=branch%3Amain)
+[![GitHub Actions CI Workflow Status](https://img.shields.io/github/actions/workflow/status/containers/compose_spec_rs/ci.yaml?branch=main&style=flat-square&logo=github&label=ci)](https://github.com/containers/compose_spec_rs/actions/workflows/ci.yaml?query=branch%3Amain)
 
 `compose_spec` is a [Rust] library crate for (de)serializing from/to the [Compose specification].
 
@@ -65,7 +65,7 @@ Increasing the MSRV is **not** considered to be a breaking change.
 
 ## Contribution
 
-Contributions, suggestions, and/or comments are appreciated! Feel free to create an [issue](https://github.com/k9withabone/compose_spec_rs/issues), [discussion](https://github.com/k9withabone/compose_spec_rs/discussions), or [pull request](https://github.com/k9withabone/compose_spec_rs/pulls).
+Contributions, suggestions, and/or comments are appreciated! Feel free to create an [issue](https://github.com/containers/compose_spec_rs/issues), [discussion](https://github.com/containers/compose_spec_rs/discussions), or [pull request](https://github.com/containers/compose_spec_rs/pulls).
 Generally, it is preferable to start a discussion for a feature request or open an issue for reporting a bug before submitting changes with a pull request.
 
 ### Project Layout

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security and Disclosure Information Policy for the `compose_spec_rs` Repository
+
+## Reporting a Vulnerability
+
+If you have identified a security vulnerability in the `compose_spec_rs` repository, please
+**do not** report the issue publicly via GitHub issues, mailing list, Discord, etc. Instead, use
+GitHub's private security vulnerability reporting feature by pressing the "Report a vulnerability"
+button on the repository's [security](https://github.com/containers/compose_spec_rs/security) page
+or privately contact one or more of the [maintainers](./MAINTAINERS.md).
+
+## Security Announcements
+
+All security vulnerabilities will be disclosed in the next
+[release](https://github.com/containers/compose_spec_rs/releases) after they are fixed.
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed as soon as is practicable given that the repository is
+maintained by a few volunteers.
+
+As the security report moves toward an identified fix and release, the maintainers will keep the
+reporter updated.


### PR DESCRIPTION
This PR is to prepare for the `compose_spec_rs` repository's move to the  `containers` GitHub organization.

- The repository links were updated.
- Added a code of conduct.
- Added contribution guidelines.

This is a draft until a security policy and maintainers list is added. I am waiting for new security policy for Podlet to be finalized (containers/podlet#183).

Closes #45