### PR TITLE
lint: allow result_large_err on into_short_iter functions

### DIFF
--- a/src/service/ports.rs
+++ b/src/service/ports.rs
@@ -31,6 +31,7 @@ pub type Ports = IndexSet<ShortOrLong<ShortPort, Port>>;
 ///
 /// If a [`Port`] cannot be represented in the [`ShortPort`] syntax, it is returned in the [`Err`]
 /// variant of the item.
+#[allow(clippy::result_large_err)]
 pub fn into_short_iter(ports: Ports) -> impl Iterator<Item = Result<ShortPort, Port>> {
     ports.into_iter().map(|port| match port {
         ShortOrLong::Short(port) => Ok(port),

--- a/src/service/volumes.rs
+++ b/src/service/volumes.rs
@@ -35,6 +35,7 @@ pub type Volumes = IndexSet<ShortOrLong<ShortVolume, Mount>>;
 ///
 /// If a volume [`Mount`] cannot be represented in the [`ShortVolume`] syntax, it is returned in the
 /// [`Err`] variant of the item.
+#[allow(clippy::result_large_err)]
 pub fn into_short_iter(volumes: Volumes) -> impl Iterator<Item = Result<ShortVolume, Mount>> {
     volumes.into_iter().map(|volume| match volume {
         ShortOrLong::Short(volume) => Ok(volume),


### PR DESCRIPTION
`clippy::result_large_err` became a default lint on newer toolchains and fires on `ports::into_short_iter` and `volumes::into_short_iter`, whose `Err` variant carries the original `Port`/`Mount` value when it cannot be represented in the short syntax.

The `into_short()` methods these delegate to already carry `#[allow(clippy::result_large_err)]`; add the same annotation to the two iterator functions for consistency and to avoid possible breaking change by swapping `Result` to with `ShortOrLong`, which might be a better call long term.